### PR TITLE
Enable GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+permissions:
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 8
+          run-install: true
+      - run: pnpm export
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./out
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,7 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  output: 'export',
 }
 
 export default nextConfig

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "build": "next build",
+    "export": "next export",
     "dev": "next dev",
     "lint": "next lint",
     "start": "next start"


### PR DESCRIPTION
## Summary
- export Next.js pages for static output
- add GitHub Actions workflow to build and deploy the `out` folder to GitHub Pages
- use the latest `upload-pages-artifact` and `deploy-pages` actions
- fix action ordering so Node installs before pnpm

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68844f2498188331b49fc220078d0d1a