### PR TITLE
Fix pnpm setup in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,13 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 8
+          run_install: false
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: 'pnpm'
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 8
       - run: pnpm install
       - run: pnpm build
       - uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- ensure pnpm is installed before Node.js setup
- upgrade to `pnpm/action-setup@v4`

## Testing
- `pnpm install`
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6884790d03f08331af74f34a8c64cf8c