### PR TITLE
Fix asset paths for static build

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
+const repoName = "Portfolio"
+
 const nextConfig = {
   eslint: {
     ignoreDuringBuilds: true,
@@ -9,7 +11,9 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
-  output: 'export',
+  output: "export",
+  basePath: process.env.NODE_ENV === "production" ? `/${repoName}` : undefined,
+  assetPrefix: process.env.NODE_ENV === "production" ? `/${repoName}/` : undefined,
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- configure assetPrefix and basePath so exported site can be hosted on GitHub Pages

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68847c2da69083318c72bfd2dcdfeb93