### PR TITLE
Add visible language toggle

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type React from "react"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import "./globals.css"
+import Script from "next/script"
 
 const inter = Inter({ subsets: ["latin"] })
 
@@ -27,7 +28,10 @@ export default function RootLayout({
         <meta name="theme-color" content="#0e0e10" />
         <meta name="color-scheme" content="dark" />
       </head>
-      <body className={`${inter.className} antialiased`}>{children}</body>
+      <body className={`${inter.className} antialiased`}>
+        {children}
+        <Script src="/translator.js" strategy="afterInteractive" />
+      </body>
     </html>
   )
 }

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -97,6 +97,11 @@ export function Navigation() {
                 <Download className="w-4 h-4 mr-2" />
                 Resume
               </Button>
+              <button
+                type="button"
+                className="language-toggle px-3 py-2 rounded-md text-sm font-medium text-[#F4F4F5] hover:bg-[#232329] focus:outline-none focus:ring-2 focus:ring-[#7EE787] focus:ring-offset-2 focus:ring-offset-[#0e0e10]"
+                aria-label="Toggle language"
+              >ES</button>
             </div>
 
             {/* Mobile Menu Button */}
@@ -157,6 +162,11 @@ export function Navigation() {
                       <Download className="w-4 h-4 mr-2" />
                       Download Resume
                     </Button>
+                    <button
+                      type="button"
+                      className="language-toggle w-full px-4 py-2 rounded-md text-sm font-medium text-[#F4F4F5] hover:bg-[#232329] focus:outline-none focus:ring-2 focus:ring-[#7EE787] focus:ring-offset-2 focus:ring-offset-[#0e0e10]"
+                      aria-label="Toggle language"
+                    >ES</button>
                   </div>
                 </div>
               </SheetContent>

--- a/public/translator.js
+++ b/public/translator.js
@@ -1,0 +1,91 @@
+(function () {
+  /**
+   * Simple bilingual translator using Google Cloud Translation API v2.
+   * All visible text is collected and translated on demand.
+   */
+  const API_URL = 'https://translation.googleapis.com/language/translate/v2?key=AIzaSyC0YXtlxqfaRYg5PWTmQfgfXwDJwZBWpuw';
+  const textNodes = [];
+  let currentLang = 'en';
+  let translations = [];
+
+  // Collect visible text nodes excluding scripts, styles and empty nodes
+  function collectTextNodes(root) {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+      acceptNode(node) {
+        if (!node.parentElement) return NodeFilter.FILTER_REJECT;
+        const tag = node.parentElement.tagName;
+        if (['SCRIPT', 'STYLE', 'NOSCRIPT'].includes(tag)) return NodeFilter.FILTER_REJECT;
+        if (!node.nodeValue.trim()) return NodeFilter.FILTER_REJECT;
+        if (getComputedStyle(node.parentElement).display === 'none') return NodeFilter.FILTER_REJECT;
+        return NodeFilter.FILTER_ACCEPT;
+      }
+    });
+    let n;
+    while ((n = walker.nextNode())) {
+      n.__original = n.nodeValue;
+      textNodes.push(n);
+    }
+  }
+
+  // Call Google Translate API to translate texts to Spanish
+  async function requestTranslations(texts) {
+    const res = await fetch(API_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        q: texts,
+        source: 'en',
+        target: 'es',
+        format: 'text'
+      })
+    });
+    const data = await res.json();
+    return data.data.translations.map(t => t.translatedText);
+  }
+
+  async function translatePage(buttons) {
+    if (!translations.length) {
+      try {
+        const texts = textNodes.map(n => n.__original);
+        translations = await requestTranslations(texts);
+      } catch (err) {
+        console.error('Translation failed', err);
+        buttons.forEach(b => (b.disabled = false));
+        return;
+      }
+    }
+    textNodes.forEach((node, i) => { node.nodeValue = translations[i]; });
+    buttons.forEach(b => {
+      b.textContent = 'EN';
+      b.disabled = false;
+    });
+    currentLang = 'es';
+    document.documentElement.lang = 'es';
+  }
+
+  function revertPage(buttons) {
+    textNodes.forEach(node => { node.nodeValue = node.__original; });
+    buttons.forEach(b => { b.textContent = 'ES'; });
+    currentLang = 'en';
+    document.documentElement.lang = 'en';
+  }
+
+  function init() {
+    collectTextNodes(document.body);
+    const buttons = Array.from(document.querySelectorAll('.language-toggle'));
+    buttons.forEach(btn => {
+      btn.textContent = 'ES';
+      btn.addEventListener('click', () => {
+        buttons.forEach(b => (b.disabled = true));
+        if (currentLang === 'en') {
+          translatePage(buttons);
+        } else {
+          revertPage(buttons);
+          buttons.forEach(b => (b.disabled = false));
+        }
+      });
+    });
+  }
+
+  window.addEventListener('DOMContentLoaded', init);
+})();


### PR DESCRIPTION
## Summary
- show "ES" on the language toggle buttons so they are visible on load
- update translator script so buttons display `ES`/`EN` and keep translations cached

## Testing
- `pnpm install`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6884870ec27c83319e698c1588b00dfa